### PR TITLE
Remove cursor after enter, Update deps, Fixed crash bugs when set sec…

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,18 +54,18 @@ function Prompt() {
   });
 
   // Set Default Format
-  if(_.isNull(this.opt.format) || _.isUndefined(this.opt.format)){
+  if (_.isNull(this.opt.format) || _.isUndefined(this.opt.format)) {
     this.opt.format = ['m', '/', 'd', '/', 'yy', ' ', 'h', ':', 'MM', ' ', 'TT'];
   }
 
   // Parse Date Parameters
-  var standardizeTime = function (date) {
+  var standardizeTime = function(date) {
     return Date.parse('1/1/2000')
-               .set({
-                 hour: date.getHours(),
-                 minute: date.getMinutes(),
-                 second: date.getSeconds()
-               });
+      .set({
+        hour: date.getHours(),
+        minute: date.getMinutes(),
+        second: date.getSeconds()
+      });
   };
 
   this.opt.date.min = (typeof this.opt.date.min === 'string') ? Date.parse(this.opt.date.min) : null;
@@ -103,11 +103,11 @@ function Prompt() {
   var opt = this.opt;
   var selection = this._selection;
 
-  var roundTo = function (num, round) {
+  var roundTo = function(num, round) {
     return Math.round(num / round) * round;
   };
 
-  var validateDate = function (datePropose) {
+  var validateDate = function(datePropose) {
     datePropose = datePropose.clone();
 
     // Validate Time
@@ -144,7 +144,7 @@ function Prompt() {
 
   this._selection.date = validateDate(this._selection.date);
 
-  _.each(this.opt.format, function (str) {
+  _.each(this.opt.format, function(str) {
     switch (str) {
       case 'd':
       case 'dd':
@@ -155,7 +155,7 @@ function Prompt() {
             selection.date = validateDate(selection.date.addDays(diff));
           },
           set: val => {
-            selection.date = validateDate(selection.date.set({day: val}));
+            selection.date = validateDate(selection.date.set({ day: val }));
           }
         });
         break;
@@ -171,7 +171,7 @@ function Prompt() {
             if (val.toString().length > 2) {
               selection.value = 0;
             }
-            selection.date = validateDate(selection.date.set({month: val - 1}));
+            selection.date = validateDate(selection.date.set({ month: val - 1 }));
           }
         });
         break;
@@ -184,7 +184,7 @@ function Prompt() {
             if (val.toString().length > 2) {
               selection.value = 0;
             }
-            selection.date = validateDate(selection.date.set({year: 2000 + val}));
+            selection.date = validateDate(selection.date.set({ year: 2000 + val }));
           }
         });
         break;
@@ -197,7 +197,7 @@ function Prompt() {
             if (val.toString().length > 4) {
               selection.value = 0;
             }
-            selection.date = validateDate(selection.date.set({year: val}));
+            selection.date = validateDate(selection.date.set({ year: val }));
           }
         });
         break;
@@ -215,9 +215,9 @@ function Prompt() {
             }
 
             if (selection.date.getHours() <= 12) {
-              selection.date = validateDate(selection.date.set({hour: val}));
+              selection.date = validateDate(selection.date.set({ hour: val }));
             } else {
-              selection.date = validateDate(selection.date.set({hour: val + 12}));
+              selection.date = validateDate(selection.date.set({ hour: val + 12 }));
             }
           }
         });
@@ -232,7 +232,7 @@ function Prompt() {
             if (val >= 60) {
               selection.value = 0;
             }
-            selection.date = validateDate(selection.date.set({minute: val}));
+            selection.date = validateDate(selection.date.set({ minute: val }));
           }
         });
         break;
@@ -240,13 +240,13 @@ function Prompt() {
       case 'ss':
         selection.elements.push({
           add: diff => {
-            selection.date = validateDate(selection.date.addSeconds(diff) * opt.time.seconds.interval);
+            selection.date = validateDate(selection.date.addSeconds(diff * opt.time.seconds.interval));
           },
           set: val => {
             if (val >= 60) {
               selection.value = 0;
             }
-            selection.date = validateDate(selection.date.set({second: val}));
+            selection.date = validateDate(selection.date.set({ second: val }));
           }
         });
         break;
@@ -280,7 +280,7 @@ util.inherits(Prompt, Base);
  * @return {this}
  */
 
-Prompt.prototype._run = function (cb) {
+Prompt.prototype._run = function(cb) {
   this.done = cb;
 
   // Once user confirm (enter key)
@@ -299,13 +299,13 @@ Prompt.prototype._run = function (cb) {
  * @return {Prompt} self
  */
 
-Prompt.prototype.render = function () {
+Prompt.prototype.render = function() {
   var message = this.getQuestion();
   var selection = this._selection;
 
-  _.each(this.opt.format, function (str, index) {
+  _.each(this.opt.format, function(str, index) {
     if (selection.cur === index) {
-      message += chalk.inverse(dateFormat(selection.date, str));
+      message += chalk.reset.inverse(dateFormat(selection.date, str));
     } else {
       message += dateFormat(selection.date, str);
     }
@@ -318,22 +318,31 @@ Prompt.prototype.render = function () {
 /**
  * When user press `enter` key
  */
-Prompt.prototype.onEnd = function () {
+Prompt.prototype.onEnd = function() {
+  var screen = this.screen;
+  var message = this.getQuestion();
+  var selection = this._selection;
+
   this.status = 'answered';
-  this.render();
-  this.screen.done();
+
+  _.each(this.opt.format, function(str) {
+    message += chalk.reset.cyan(dateFormat(selection.date, str));
+  });
+
+  screen.render(message);
+  screen.done();;
   cliCursor.show();
-  this.done(this._selection.date);
+  this.done(selection.date);
 };
 
 /**
  * When user press a key
  */
 
-Prompt.prototype.onKeypress = function (e) {
+Prompt.prototype.onKeypress = function(e) {
   var res;
   var selection = this._selection;
-  var isSelectable = function (obj) {
+  var isSelectable = function(obj) {
     return obj !== null;
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inquirer-datepicker-prompt",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Datepicker prompt for inquirer.js",
   "main": "index.js",
   "scripts": {
@@ -24,16 +24,16 @@
   },
   "homepage": "https://github.com/DerekTBrown/inquirer-datepicker-prompt#readme",
   "dependencies": {
-    "chalk": "^1.1.3",
+    "chalk": "^2.1.0",
     "cli-cursor": "^2.1.0",
-    "dateformat": "^2.0.0",
+    "dateformat": "^3.0.2",
     "datejs": "^1.0.0-rc3",
-    "inquirer": "^3.1.1",
+    "inquirer": "^3.3.0",
     "lodash": "^4.17.4",
     "util": "^0.10.3"
   },
   "devDependencies": {
     "jscs": "^3.0.7",
-    "jshint": "^2.9.4"
+    "jshint": "^2.9.5"
   }
 }


### PR DESCRIPTION
- Update deps
- Adjust some code styles
- Fixed crash bugs when set seconds (an old bugs [L243](https://github.com/DerekTBrown/inquirer-datepicker-prompt/blob/v0.3.3/index.js#L243))
- Remove cursor background color after press enter key #5 
- Use ```chalk.reset``` before set color, to prevent some unexpected display results

![tim 20170924104856](https://user-images.githubusercontent.com/1730277/30779005-04049ce2-a116-11e7-883e-6f4c178e9578.png)

![tim 20170924102415](https://user-images.githubusercontent.com/1730277/30778916-ea8c1ea4-a113-11e7-8632-fcb1caf3dc72.png)